### PR TITLE
entrega hito 5

### DIFF
--- a/proyectos/hito-5.md
+++ b/proyectos/hito-5.md
@@ -18,7 +18,7 @@ versionado semántico para la versión en la columna correspondiente.
 | CORREA FERNANDEZ,  GEMA | | |
 | DE LA TORRE RODRIGUEZ,  ADRIAN | https://github.com/adritake/CC_UGR_Personal | 5.0 |
 | DE OLIVEIRA DIAS GONÇALVES, MIGUEL | | |
-| GALLEGO QUERO,  LUIS | | |
+| GALLEGO QUERO,  LUIS | https://github.com/luiisgallego/MII_CC_1819 | 5.0 |
 | GOMEZ-PORTILLO LOPEZ,  PEDRO MANUEL | https://github.com/gomezportillo/apolo | 5 |
 | GRIMM,  ALEXANDER MANUEL JOSEF | https://github.com/alex1ai/ugr-master-cc | 5.0 |
 | MARTÍN VALERA, JONATHAN | | |


### PR DESCRIPTION
# Entrega del hito de Cloud Computing

Corresponde al hito 5

## Enlace a fichero de objetivos 

https://github.com/JJ/CC-18-19/blob/master/objetivos/luiisgallego.md

## Lista de comprobación para hitos (*borrar si no es un hito*)

* [X] He leído el guión del hito
* [X] Cumplo los prerrequisitos (he aprobado el hito anterior, por ejemplo)
* [X] He actualizado con la última versión del fichero de entrega (y resto del repositorio).
* [ ] He [seguido las instrucciones para reenvíos](http://jj.github.io/CC/documentos/proyecto/Reenvios) *sólo en caso de reenvío*.
  
## Descripción de la entrega

En esta nueva entrega se ha desarrollado todo el despliegue del proyecto mediante Vagrant, además se ha cambiado la base de datos a mongodb de forma local, lo que nos permite tener dos microservicios totalmente independientes. Para esta base de datos ha sido necesario la construcción de un playbook específico.

## Hitos e *issues* del repositorio que se han cerrado con esta entrega (si se trata de un hito (*a partir del primer hito, borrar si no es un hito*)

Todos los issues de este hito lo podemos encontrar en el milestone 5, concretamente se han definido los siguientes:
- [51](https://github.com/luiisgallego/MII_CC_1819/issues/51) Una vez que teníamos una versión inicial funcional de Vagrant en el repositorio de ejercicios, pasamos los archivos necesarios al principal y realizamos los ajustes necesarios.
- [54](https://github.com/luiisgallego/MII_CC_1819/issues/54) Para el traslado de la base de datos a local, dejando el servicio mlab.
- [52](https://github.com/luiisgallego/MII_CC_1819/issues/52) Toda la documentación necesaria.
- [53](https://github.com/luiisgallego/MII_CC_1819/issues/53) Para todo el proceso de definición del archivo de Vagrant.

